### PR TITLE
Closes #67: Add option default_desired_privilege_level

### DIFF
--- a/netbox_config_diff/compliance/base.py
+++ b/netbox_config_diff/compliance/base.py
@@ -130,7 +130,7 @@ class ConfigDiffBase(SecretsMixin):
         self.check_netbox_secrets()
         self.substitutes = {}
         for device in devices:
-            username, password, auth_secondary = self.get_credentials(device)
+            username, password, auth_secondary, default_desired_privilege_level = self.get_credentials(device)
             rendered_config = None
             error = None
             context_data = device.get_config_context()
@@ -159,6 +159,7 @@ class ConfigDiffBase(SecretsMixin):
                 username=username,
                 password=password,
                 auth_secondary=auth_secondary,
+                default_desired_privilege_level=default_desired_privilege_level,
                 rendered_config=rendered_config,
                 error=error,
                 device=device,

--- a/netbox_config_diff/compliance/secrets.py
+++ b/netbox_config_diff/compliance/secrets.py
@@ -45,9 +45,9 @@ class SecretsMixin:
             return None
         return secret.plaintext
 
-    def get_credentials(self, device: Device) -> tuple[str, str, str]:
+    def get_credentials(self, device: Device) -> tuple[str, str, str, str]:
         if not self.netbox_secrets_installed:
-            return self.username, self.password, self.auth_secondary
+            return self.username, self.password, self.auth_secondary, self.default_desired_privilege_level
 
         if secret := device.secrets.filter(role__name=self.user_role).first():
             username = value if (value := self.get_secret(secret)) else self.username
@@ -61,8 +61,13 @@ class SecretsMixin:
             auth_secondary = value if (value := self.get_secret(secret)) else self.auth_secondary
         else:
             auth_secondary = self.auth_secondary
+        if secret := device.secrets.filter(role__name=self.default_desired_privilege_level_role).first():
+            default_desired_privilege_level = value if (value := self.get_secret(secret)) else self.default_desired_privilege_level
+        else:
+            default_desired_privilege_level = self.default_desired_privilege_level
 
-        return username, password, auth_secondary
+
+        return username, password, auth_secondary, default_desired_privilege_level
 
     def check_netbox_secrets(self) -> None:
         if "netbox_secrets" in get_installed_plugins():
@@ -70,8 +75,10 @@ class SecretsMixin:
             self.user_role = get_plugin_config("netbox_config_diff", "USER_SECRET_ROLE")
             self.password_role = get_plugin_config("netbox_config_diff", "PASSWORD_SECRET_ROLE")
             self.auth_secondary_role = get_plugin_config("netbox_config_diff", "SECOND_AUTH_SECRET_ROLE")
+            self.default_desired_privilege_level_role = get_plugin_config("netbox_config_diff", "DEFAULT_DESIRED_PRIVILEGE_LEVEL_ROLE")
             self.netbox_secrets_installed = True
 
         self.username = get_plugin_config("netbox_config_diff", "USERNAME")
         self.password = get_plugin_config("netbox_config_diff", "PASSWORD")
         self.auth_secondary = get_plugin_config("netbox_config_diff", "AUTH_SECONDARY")
+        self.default_desired_privilege_level = get_plugin_config("netbox_config_diff", "DEFAULT_DESIRED_PRIVILEGE_LEVEL")

--- a/netbox_config_diff/configurator/base.py
+++ b/netbox_config_diff/configurator/base.py
@@ -37,7 +37,7 @@ class Configurator(SecretsMixin):
     def validate_devices(self) -> None:
         self.check_netbox_secrets()
         for device in self.devices:
-            username, password, auth_secondary = self.get_credentials(device)
+            username, password, auth_secondary, default_desired_privilege_level = self.get_credentials(device)
             if device.platform.platform_setting is None:
                 self.logger.log_warning(f"Skipping {device}, add PlatformSetting for {device.platform} platform")
             elif device.platform.platform_setting.driver not in ACCEPTABLE_DRIVERS:
@@ -67,6 +67,7 @@ class Configurator(SecretsMixin):
                     username=username,
                     password=password,
                     auth_secondary=auth_secondary,
+                    default_desired_privilege_level=default_desired_privilege_level,
                     rendered_config=rendered_config,
                     error=error,
                 )

--- a/netbox_config_diff/models/data_models.py
+++ b/netbox_config_diff/models/data_models.py
@@ -28,6 +28,7 @@ class BaseDeviceDataClass:
     config_error: str | None = None
     auth_strict_key: bool = False
     auth_secondary: str | None = None
+    default_desired_privilege_level: str | None = None
     transport: str = "asyncssh"
 
     def __str__(self) -> str:
@@ -41,6 +42,7 @@ class BaseDeviceDataClass:
             "platform": self.platform,
             "auth_strict_key": self.auth_strict_key,
             "auth_secondary": self.auth_secondary,
+            "default_desired_privilege_level": self.default_desired_privilege_level,
             "transport": self.transport,
             "transport_options": {
                 "asyncssh": {


### PR DESCRIPTION
Issue: https://github.com/miaow2/netbox-config-diff/issues/67

Add the option "default_desired_privilege_level" as configuration parameter for config scraping without enable mode.

You can disable the pagination on some network devices globally for all.