### PR TITLE
fix:  log correctly if session key is not available.

### DIFF
--- a/netbox_config_diff/compliance/secrets.py
+++ b/netbox_config_diff/compliance/secrets.py
@@ -34,8 +34,8 @@ class SecretsMixin:
             sk = SessionKey.objects.get(userkey__user=self.request.user)
             self.master_key = sk.get_master_key(self.session_key)
         except Exception as e:
-            if getattr(self, "logger"):
-                if getattr(self.logger, "log_failure"):
+            if hasattr(self, "logger"):
+                if hasattr(self.logger, "log_failure"):
                     self.logger.log_failure(f"Can't fetch master_key: {str(e)}")
                 else:
                     self.logger.error(f"Can't fetch master_key: {str(e)}")


### PR DESCRIPTION
Right now, a missing session key may result in the following stacktrace.

```
  File "/opt/netbox/venv/lib/python3.12/site-packages/netbox_config_diff/compliance/base.py", line 166, in get_devices_with_rendered_configs
    self.check_netbox_secrets()
  File "/opt/netbox/venv/lib/python3.12/site-packages/netbox_config_diff/compliance/secrets.py", line 94, in check_netbox_secrets
    self.get_master_key()
  File "/opt/netbox/venv/lib/python3.12/site-packages/netbox_config_diff/compliance/secrets.py", line 39, in get_master_key
    if getattr(self.logger, "log_failure"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Logger' object has no attribute 'log_failure'
```